### PR TITLE
feat: increase gas limit to 50 million for subgraph compatibility

### DIFF
--- a/k8s-deploy/k8s/axon/axon-config/node_1.toml
+++ b/k8s-deploy/k8s/axon/axon-config/node_1.toml
@@ -6,8 +6,9 @@ data_path = "./devtools/chain/data1"
 
 epoch_len = 100_000_000
 
-metadata_contract_address = "0xc2fd48d60ae16b3fe6e333a9a13763691970d9373d4fab7cc323d7ba06fa9986"
-crosschain_contract_address = "0x2c3a9349df5b162519b17621f67bc4e50d1df92b0e4c61794a4517af6a995cb2"
+metadata_contract_address = "0xb00d616b820c39619ee29e5144d0226cf8b5c15a"
+crosschain_contract_address = "0xb484fd480e598621638f380f404697cd9f58b0f8"
+wckb_contract_address = "0x4af5ec5e3d29d9ddd7f4bf91a022131c41b72352"
 
 [accounts]
 mnemonic = "test test test test test test test test test test test junk"

--- a/k8s-deploy/k8s/axon/axon-config/node_2.toml
+++ b/k8s-deploy/k8s/axon/axon-config/node_2.toml
@@ -6,8 +6,9 @@ data_path = "./devtools/chain/data2"
 
 epoch_len = 100_000_000
 
-metadata_contract_address = "0xc2fd48d60ae16b3fe6e333a9a13763691970d9373d4fab7cc323d7ba06fa9986"
-crosschain_contract_address = "0x2c3a9349df5b162519b17621f67bc4e50d1df92b0e4c61794a4517af6a995cb2"
+metadata_contract_address = "0xb00d616b820c39619ee29e5144d0226cf8b5c15a"
+crosschain_contract_address = "0xb484fd480e598621638f380f404697cd9f58b0f8"
+wckb_contract_address = "0x4af5ec5e3d29d9ddd7f4bf91a022131c41b72352"
 
 [accounts]
 mnemonic = "test test test test test test test test test test test junk"

--- a/k8s-deploy/k8s/axon/axon-config/node_3.toml
+++ b/k8s-deploy/k8s/axon/axon-config/node_3.toml
@@ -6,8 +6,9 @@ data_path = "./devtools/chain/data3"
 
 epoch_len = 100_000_000
 
-metadata_contract_address = "0xc2fd48d60ae16b3fe6e333a9a13763691970d9373d4fab7cc323d7ba06fa9986"
-crosschain_contract_address = "0x2c3a9349df5b162519b17621f67bc4e50d1df92b0e4c61794a4517af6a995cb2"
+metadata_contract_address = "0xb00d616b820c39619ee29e5144d0226cf8b5c15a"
+crosschain_contract_address = "0xb484fd480e598621638f380f404697cd9f58b0f8"
+wckb_contract_address = "0x4af5ec5e3d29d9ddd7f4bf91a022131c41b72352"
 
 [accounts]
 mnemonic = "test test test test test test test test test test test junk"

--- a/k8s-deploy/k8s/axon/axon-config/node_4.toml
+++ b/k8s-deploy/k8s/axon/axon-config/node_4.toml
@@ -6,8 +6,9 @@ data_path = "./devtools/chain/data4"
 
 epoch_len = 100_000_000
 
-metadata_contract_address = "0xc2fd48d60ae16b3fe6e333a9a13763691970d9373d4fab7cc323d7ba06fa9986"
-crosschain_contract_address = "0x2c3a9349df5b162519b17621f67bc4e50d1df92b0e4c61794a4517af6a995cb2"
+metadata_contract_address = "0xb00d616b820c39619ee29e5144d0226cf8b5c15a"
+crosschain_contract_address = "0xb484fd480e598621638f380f404697cd9f58b0f8"
+wckb_contract_address = "0x4af5ec5e3d29d9ddd7f4bf91a022131c41b72352"
 
 [accounts]
 mnemonic = "test test test test test test test test test test test junk"

--- a/k8s-deploy/k8s/axon/axon1-statefulset.yaml
+++ b/k8s-deploy/k8s/axon/axon1-statefulset.yaml
@@ -57,7 +57,7 @@ spec:
             - ./axon
             - -c=/app/devtools/chain/k8s/node_1.toml
             - -g=/app/devtools/chain/genesis.json
-          image: zhengjianhui/axon-k8s:latest
+          image: ghcr.io/tvl-labs/axon:0.0.5
           volumeMounts:
           - name: config-node1
             mountPath: /app/devtools/chain/k8s/node_1.toml

--- a/k8s-deploy/k8s/axon/axon2-statefulset.yaml
+++ b/k8s-deploy/k8s/axon/axon2-statefulset.yaml
@@ -57,7 +57,7 @@ spec:
             - ./axon
             - -c=/app/devtools/chain/k8s/node_2.toml
             - -g=/app/devtools/chain/genesis.json
-          image: zhengjianhui/axon-k8s:latest
+          image: ghcr.io/tvl-labs/axon:0.0.5
           volumeMounts:
           - name: config-node2
             mountPath: /app/devtools/chain/k8s/node_2.toml

--- a/k8s-deploy/k8s/axon/axon3-statefulset.yaml
+++ b/k8s-deploy/k8s/axon/axon3-statefulset.yaml
@@ -57,7 +57,7 @@ spec:
             - ./axon
             - -c=/app/devtools/chain/k8s/node_3.toml
             - -g=/app/devtools/chain/genesis.json
-          image: zhengjianhui/axon-k8s:latest
+          image: ghcr.io/tvl-labs/axon:0.0.5
           volumeMounts:
           - name: config-node3
             mountPath: /app/devtools/chain/k8s/node_3.toml

--- a/k8s-deploy/k8s/axon/axon4-statefulset.yaml
+++ b/k8s-deploy/k8s/axon/axon4-statefulset.yaml
@@ -57,7 +57,7 @@ spec:
             - ./axon
             - -c=/app/devtools/chain/k8s/node_4.toml
             - -g=/app/devtools/chain/genesis.json
-          image: zhengjianhui/axon-k8s:latest
+          image: ghcr.io/tvl-labs/axon:0.0.5
 
           volumeMounts:
           - name: config-node4


### PR DESCRIPTION
This PR increases support gas limit to 50 million for read calls. Also it updates Axon chain configs because for example metadata_contract_address is now length 40 instead of 64.

Test case: eth_call with gas limit 50,000,000

Before:
![image](https://user-images.githubusercontent.com/4950658/197834562-9cadcaba-4121-48fa-b3c8-d8f9945311a0.png)

After:
![image](https://user-images.githubusercontent.com/4950658/197834591-ad1cf1d6-72e2-4d26-8ec8-9ec3828fb06e.png)

Tested locally on k8s using port forwarding from the service.
![image](https://user-images.githubusercontent.com/4950658/197834642-ee97413e-5a41-49f6-9b02-9050686151b9.png)
![image](https://user-images.githubusercontent.com/4950658/197834715-b94425c7-261e-4e89-9bd7-169783232f73.png)
